### PR TITLE
Add immediate optional param to scheduling, fixes #3

### DIFF
--- a/tasko/__init__.py
+++ b/tasko/__init__.py
@@ -27,6 +27,7 @@ def get_loop(debug=tasko_logging):
 
 add_task = get_loop().add_task
 schedule = get_loop().schedule
+schedule_later = get_loop().schedule_later
 sleep = get_loop().sleep
 suspend = get_loop().suspend
 

--- a/tasko/loop.py
+++ b/tasko/loop.py
@@ -142,6 +142,23 @@ class Loop:
 
         self.add_task(schedule_at_rate(coroutine_function))
 
+    def schedule_later(self, hz: float, coroutine_function, *args, **kwargs):
+        """
+        Like schedule, but invokes the coroutine_function after the first hz interval.
+
+        See schedule api for parameters.
+        """
+        ran_once = False
+        async def call_later():
+            nonlocal ran_once
+            if ran_once:
+                await coroutine_function(*args, **kwargs)
+            else:
+                await _yield_once()
+                ran_once = True
+
+        return self.schedule(hz, call_later)
+
     def run(self):
         """
         Use:

--- a/test/test_managed_resource.py
+++ b/test/test_managed_resource.py
@@ -1,7 +1,7 @@
 import time
 from unittest import TestCase
 
-from managed_resource import ManagedResource
+from tasko.managed_resource import ManagedResource
 from tasko import Loop
 
 
@@ -47,19 +47,19 @@ class TestManagedResource(TestCase):
         loop._step()  # 1 acquire-work  2 suspend
         # 1 is working with spi on cs1, 2 is suspended waiting.
         self.assertIs(spi.active_cs, 1)
-        self.assertEquals(len(loop._tasks), 1)  # 2 is suspended, not eligible to be run next step
+        self.assertEqual(len(loop._tasks), 1)  # 2 is suspended, not eligible to be run next step
 
         loop._step()  # 1 after context
         self.assertIsNone(spi.active_cs)
-        self.assertEquals(len(loop._tasks), 2)  # 1 is unfinished, 2 is unsuspended by the ManagedResource
+        self.assertEqual(len(loop._tasks), 2)  # 1 is unfinished, 2 is unsuspended by the ManagedResource
 
         loop._step()  # 1 end           2 work
         self.assertIs(spi.active_cs, 2)
-        self.assertEquals(len(loop._tasks), 1)  # 1 is finished, 2 is working with spi on cs2
+        self.assertEqual(len(loop._tasks), 1)  # 1 is finished, 2 is working with spi on cs2
 
         loop._step()  #                 2 after context
         self.assertIsNone(spi.active_cs)
-        self.assertEquals(len(loop._tasks), 1)  # 2 is unfinished
+        self.assertEqual(len(loop._tasks), 1)  # 2 is unfinished
 
         loop._step()  # 2 end
-        self.assertEquals(loop._tasks, [])  # 2 is finished
+        self.assertEqual(loop._tasks, [])  # 2 is finished


### PR DESCRIPTION
This allows to schedule a task first run after the hz interval and not immediately (which is the default)