### PR TITLE
fixing  minor typo in debug

### DIFF
--- a/tasko/loop.py
+++ b/tasko/loop.py
@@ -278,7 +278,7 @@ class Loop:
                 # and nothing else is scheduled to run for this long.
                 # This is the real sleep. If/when interrupts are implemented this will likely need to change.
                 sleep_seconds = sleep_nanos / 1000000000.0
-                self._debug('No active tasks.  Sleeping for ', sleep_seconds, 'ns. \n', self._sleeping)
+                self._debug('No active tasks.  Sleeping for ', sleep_seconds, 's. \n', self._sleeping)
                 time.sleep(sleep_seconds)
 
     def _run_task(self, task: Task):


### PR DESCRIPTION
When there aren't any active tasks, debug was printing "No active tasks.  Sleeping for  9.77063 **ns**" when it should say "s" not "ns." 

Minor typo but I spent a few moments troubleshooting my code thinking timing was off so I figured it was worth a PR. @WarriorOfWire 